### PR TITLE
WarWind: Add palette reader

### DIFF
--- a/core/src/retrogdx/games/warwind/WarWind.java
+++ b/core/src/retrogdx/games/warwind/WarWind.java
@@ -3,10 +3,15 @@ package retrogdx.games.warwind;
 import com.badlogic.gdx.files.FileHandle;
 import retrogdx.games.warwind.nodes.DatNode;
 import retrogdx.games.warwind.nodes.ResNode;
+import retrogdx.games.warwind.readers.Pal;
 import retrogdx.ui.nodes.AssetFileNode;
 import retrogdx.ui.nodes.GameNode;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class WarWind extends GameNode {
+    public static Map<String, Pal> PALETTES = new HashMap<>();
     public WarWind() {
         super("War Wind");
     }

--- a/core/src/retrogdx/games/warwind/nodes/D3grNode.java
+++ b/core/src/retrogdx/games/warwind/nodes/D3grNode.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Sprite;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import retrogdx.games.warwind.WarWind;
 import retrogdx.games.warwind.readers.D3gr;
 import retrogdx.ui.nodes.AssetFileNode;
 import retrogdx.ui.previews.ImageSetPreview;
@@ -26,7 +27,11 @@ public class D3grNode extends AssetFileNode {
             for (int y = 0; y < frame.height; y++) {
                 for (int x = 0; x < frame.width; x++) {
                     int index = frame.pixels[x + y * frame.width] & 0xff;
-                    pixmap.drawPixel(x, y, (index << 24) | (index << 16) | (index << 8) | 0xff);
+                    if (WarWind.PALETTES.containsKey("0.PAL")) {
+                        pixmap.drawPixel(x, y, WarWind.PALETTES.get("0.PAL").colors[index]);
+                    } else {
+                        pixmap.drawPixel(x, y, (index << 24) | (index << 16) | (index << 8) | 0xff);
+                    }
                 }
             }
 

--- a/core/src/retrogdx/games/warwind/nodes/PalNode.java
+++ b/core/src/retrogdx/games/warwind/nodes/PalNode.java
@@ -15,10 +15,10 @@ public class PalNode extends AssetFileNode {
     public void showPreview(Table previewArea) {
         Pal pal = new Pal(this.buffer);
 
-        Pixmap pixmap = new Pixmap(256, 256, Pixmap.Format.RGBA8888);
+        Pixmap pixmap = new Pixmap(16, 16, Pixmap.Format.RGBA8888);
 
-        for (int i = 0; i < 256 * 256; i++) {
-            pixmap.drawPixel(i % 256, i / 256, pal.colors[i]);
+        for (int i = 0; i < 16 * 16; i++) {
+            pixmap.drawPixel(i % 16, i / 16, pal.colors[i]);
         }
 
         previewArea.add(new ImagePreview(pixmap));

--- a/core/src/retrogdx/games/warwind/nodes/ResNode.java
+++ b/core/src/retrogdx/games/warwind/nodes/ResNode.java
@@ -3,6 +3,8 @@ package retrogdx.games.warwind.nodes;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.scenes.scene2d.ui.Tree;
 import com.badlogic.gdx.utils.Array;
+import retrogdx.games.warwind.WarWind;
+import retrogdx.games.warwind.readers.Pal;
 import retrogdx.games.warwind.readers.Res;
 import retrogdx.generic.nodes.RiffWaveNode;
 import retrogdx.ui.nodes.GameNode;
@@ -28,6 +30,7 @@ public class ResNode extends FolderVirtualNode {
                 nodes.add(new D3grNode(file.getKey(), file.getValue()));
             } else if (file.getKey().endsWith(".PAL")) {
                 nodes.add(new PalNode(file.getKey(), file.getValue()));
+                WarWind.PALETTES.put(file.getKey(), new Pal(file.getValue()));
             } else {
                 System.out.println("Unknown file format: " + file.getKey());
             }

--- a/core/src/retrogdx/games/warwind/readers/Pal.java
+++ b/core/src/retrogdx/games/warwind/readers/Pal.java
@@ -5,16 +5,24 @@ import retrogdx.utils.SmartByteBuffer;
 import java.nio.ByteOrder;
 
 public class Pal {
-    public int[] colors = new int[256 * 256];
+    public int[] colors = new int[256];
 
     public Pal(SmartByteBuffer buffer) {
         buffer.order(ByteOrder.LITTLE_ENDIAN);
         buffer.position(0);
 
-        for (int i = 0; i < 256 * 256; i++) {
-            // TODO find correct palette format!
-            int value = buffer.readUByte();
-            this.colors[i] = (value << 24) | (value << 16) | (value << 8) | 0xff;
+        buffer.readString(4); // D3GR
+        int flags = buffer.readInt(); // 0x2001
+        int framesStart = buffer.readInt();
+        int paletteStart = buffer.readInt();
+
+        buffer.position(4 + paletteStart); //skip 4 bytes D3GR header also
+
+        for (int i = 0; i < 256; i++) {
+            int r = buffer.readUByte() << 2;
+            int g = buffer.readUByte() << 2;
+            int b = buffer.readUByte() << 2;
+            this.colors[i] = (r << 24) | (g << 16) | (b << 8) | 0xff;
         }
     }
 }

--- a/core/src/retrogdx/games/warwind/readers/Res.java
+++ b/core/src/retrogdx/games/warwind/readers/Res.java
@@ -35,7 +35,16 @@ public class Res {
 
             switch (test) {
                 case 0x3344:
-                    files.put(i + ".D3GR", fileBuffer);
+                    fileBuffer.position(4);
+                    int flags = fileBuffer.readInt();
+                    fileBuffer.position(0);
+                    switch (flags) {
+                        case 0x2001:
+                            files.put(i + ".PAL", fileBuffer);
+                            break;
+                        default: //0x8001
+                            files.put(i + ".D3GR", fileBuffer);
+                    }
                     break;
                 case 0x4952:
                     files.put(i + ".WAV", fileBuffer);
@@ -44,7 +53,7 @@ public class Res {
                     // Nothing here - removed file.
                     break;
                 default:
-                    files.put(i + ".PAL", fileBuffer);
+                    files.put(i + ".UNK", fileBuffer);
                     break;
             }
         }


### PR DESCRIPTION
Palettes of 256 colors is also in ".D3GR" files, just with different flag value. There are 2 palettes in RES.001 and a few more in RES.004, but for the most sprites "0.PAL" from "RES.001" is used. Still can't find the the palette chooser though; looks like it is not in the sprite ".D3GR" file.

<img width="571" alt="Screen Shot 2023-01-28 at 21 36 58" src="https://user-images.githubusercontent.com/5202417/215270123-03432077-64a5-4962-afa0-68d9b64da418.png">

<img width="572" alt="Screen Shot 2023-01-28 at 21 38 08" src="https://user-images.githubusercontent.com/5202417/215270104-43021515-83b7-4524-b2c1-108bf0c0e178.png">
